### PR TITLE
Fix typings test on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     ],
     "exclude": [
       "lib/**/*.test.*",
+      "lib/**/*.integration.*",
       "lib/**/*.d.ts",
       "lib/**/*.map*"
     ]

--- a/src/index.integration.ts
+++ b/src/index.integration.ts
@@ -1,11 +1,13 @@
 import * as cp from 'child_process';
 import * as path from 'path';
+import * as os from 'os';
 import { assert } from 'chai';
 
 describe('typings', () => {
   it('compiles successfully', function (): void {
     this.timeout(10000);
-    const result = cp.spawnSync('tsc', { cwd: path.resolve('./fixtures/typings-test')});
-    assert.equal(result.status, 0, `build did not succeed:\nstdout: ${result.stdout.toString()}\nstderr: ${result.stderr.toString()}\n`);
+    const command = os.platform() === 'win32' ? 'tsc.cmd' : 'tsc';
+    const result = cp.spawnSync(command, { cwd: path.resolve('./fixtures/typings-test')});
+    assert.equal(result.status, 0, `build did not succeed:\nstdout: ${String(result.stdout)}\nstderr: ${String(result.stderr)}\n`);
   });
 });


### PR DESCRIPTION
`tsc` needs to be invoked as `tsc.cmd` on Windows. Otherwise, there are failures as noted in https://github.com/xtermjs/xterm-addon-ligatures/pull/7#issuecomment-411941931.

Also noticed the integration tests were slipping into the coverage so pulled that out too.