### PR TITLE
Move xterm.js dependency to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
     "tslint": "^5.9.1",
     "tslint-consistent-codestyle": "^1.13.0",
     "typescript": "^2.8.3",
-    "xterm": "^3.5.0",
+    "xterm": "^3.6.0",
     "yauzl": "^2.10.0"
   },
   "peerDependencies": {
-    "xterm": "^3.5.0"
+    "xterm": "^3.6.0"
   },
   "nyc": {
     "sourceMap": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,7 @@ export function enableLigatures(term: Terminal): void {
   let loadingState: LoadingState = LoadingState.UNLOADED;
   let loadError: any | undefined = undefined;
 
-  // TODO: remove any once 3.6.0 is published
-  (term as any).registerCharacterJoiner((text: string): [number, number][] => {
+  term.registerCharacterJoiner((text: string): [number, number][] => {
     // If the font hasn't been loaded yet, load it and return an empty result
     const termFont = term.getOption('fontFamily');
     if (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,9 +1851,9 @@ write-file-atomic@^1.1.4:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
-xterm@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.5.0.tgz#ba3f464bc5730c9d259ebe62131862224db9ddcc"
+xterm@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.6.0.tgz#9b95cd23a338e5842343aec1a104f094c5153e7c"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Version 3.6.0 of `xterm` contains the actual code needed for this package to function. Now that it's published, we can move all of the references to the right version.